### PR TITLE
Add candlestick chart generation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,18 @@ Ceci est un Bot Telegram qui a pour but de m'aider à trader les tendances de fa
 Nouveauté : il est maintenant possible de définir des alertes de prix avec la commande `/alert` et de les supprimer avec `/removealert`. Tu peux également afficher la liste de tes alertes avec `/alerts`. Le bot te notifiera dès que la valeur choisie est atteinte.
 
 Attention ! Le Trading comporte des risques. Ce bot ne donnes pas de conseils financiers.
+
+## Utilisation de /chart
+
+La commande `/chart` affiche un graphique en chandeliers avec l'EMA100.
+
+```
+/chart BTC/USDT 4h
+```
+
+Le graphique est généré grâce à `mplfinance`. Pense à installer les dépendances :
+
+```
+pip install -r requirements.txt
+```
+

--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -9,6 +9,7 @@ from telegram.ext import (
 
 from services.price_fetcher import fetch_ohlcv
 from services.technical_analysis import compute_ema, EMA_PERIOD
+from services.chart_generator import generate_chart
 
 from database.connection import SessionLocal
 from database.crud import (
@@ -202,10 +203,25 @@ async def remove_alert_command(update, context):
 
 
 async def chart_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    # """Envoie un graphique OHLCV avec EMAs pour toutes les paires surveillées."""
-    # buf = generate_chart(update.effective_chat.id)
-    # await update.message.reply_photo(photo=buf)
-    await update.message.reply_text("📊 La génération de graphiques n'est pas encore disponible.")
+    """Génère et envoie un graphique OHLCV avec l'EMA100."""
+    args = context.args
+    if not args:
+        await update.message.reply_text(
+            "❌ Utilisation : /chart <SYMBOL> [TIMEFRAME]\nExemple : /chart BTC/USDT 4h"
+        )
+        return
+
+    symbol = args[0].upper()
+    timeframe = args[1] if len(args) > 1 else "1h"
+
+    try:
+        buf = generate_chart(symbol, timeframe)
+        await update.message.reply_photo(photo=buf)
+    except Exception as e:
+        await update.message.reply_text(
+            f"❌ Impossible de générer le graphique pour {symbol} en {timeframe}."
+        )
+        print(f"[ERREUR] /chart {symbol} {timeframe} : {e}")
 
 async def last_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     args = context.args

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ APScheduler==3.11.0
 ccxt==4.4.85
 pandas==2.0.3
 SQLAlchemy==2.0.41
+mplfinance==0.12.9b7

--- a/services/chart_generator.py
+++ b/services/chart_generator.py
@@ -1,0 +1,44 @@
+import io
+import mplfinance as mpf
+
+from services.price_fetcher import fetch_ohlcv
+from services.technical_analysis import compute_ema, EMA_PERIOD
+
+
+def generate_chart(symbol: str, timeframe: str = "1h") -> io.BytesIO:
+    """Generate a candlestick chart with EMA overlay.
+
+    Parameters
+    ----------
+    symbol: str
+        Trading pair symbol like ``"BTC/USDT"``.
+    timeframe: str
+        Exchange timeframe (for example ``"4h"`` or ``"1d"``).
+
+    Returns
+    -------
+    io.BytesIO
+        Buffer containing the PNG image ready to be sent to Telegram.
+    """
+    # Fetch candles and compute EMA
+    limit = EMA_PERIOD + 50
+    df = fetch_ohlcv(symbol, timeframe=timeframe, limit=limit)
+    df = compute_ema(df, span=EMA_PERIOD)
+
+    df = df.set_index("timestamp")
+
+    apds = [mpf.make_addplot(df["ema"], color="orange", width=1)]
+
+    fig, _ = mpf.plot(
+        df,
+        type="candle",
+        style="binance",
+        addplot=apds,
+        volume=True,
+        returnfig=True,
+    )
+
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png")
+    buf.seek(0)
+    return buf


### PR DESCRIPTION
## Summary
- create `chart_generator` service using mplfinance for EMA charts
- add plotting dependency
- implement `/chart` command to reply with generated chart
- document how to use `/chart`

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6870e1fe93d88330984c173d5ec5467e